### PR TITLE
Adds a sleep to remote-devtools Upstart job before SSH tunnel

### DIFF
--- a/remote_devtools.sh
+++ b/remote_devtools.sh
@@ -36,6 +36,7 @@ end script
 
 expect fork
 script
+  sleep 5
   exec ssh -oStrictHostKeyChecking=no -L 0.0.0.0:9223:localhost:9222 localhost -N
 end script
 EOL


### PR DESCRIPTION
Adds a sleep to remote-devtools Upstart job before SSH tunnel.

On recent Chrome OS versions (~63) the openssh Upstart job takes long enough to complete that its "started" event triggers the remote-devtools Upstart job before OpenSSH is listening on port 22, which causes the exec command to open an SSH tunnel to fail silently. Adding a sleep command to the remote-devtools script gives OpenSSH time to fully load.